### PR TITLE
Make jobs

### DIFF
--- a/LINUX_BUILD_INSTRUCTIONS
+++ b/LINUX_BUILD_INSTRUCTIONS
@@ -27,7 +27,7 @@ cd build
 
 cmake -DCMAKE_INSTALL_PREFIX=/usr -DQT5=true -DCMAKE_BUILD_TYPE=RELEASE . ..
 
-make
+make -j$(nproc)
 
 make install( or sudo make install )
 

--- a/OSX_BUILD_INSTRUCTIONS
+++ b/OSX_BUILD_INSTRUCTIONS
@@ -20,11 +20,12 @@ Below are instructions on how to build SiriKali on OSX.
     # Inside the directory of the cloned repository
 6.  mkdir build
 7.  cd build
-    #You need to specify the path to the qt5 you installed through homebrew:
+    # You need to specify the path to the qt5 you installed through homebrew:
 8.  export CMAKE_PREFIX_PATH=/usr/local/opt/qt5/
-    #Then you'll be able to compile Sirikali to $HOME/sirikali
+    # Then you'll be able to compile Sirikali to $HOME/sirikali
 9.  cmake -DCMAKE_INSTALL_PREFIX=$HOME/sirikali -DQT5=true -DCMAKE_BUILD_TYPE=RELEASE . ..
-10. make
+	# Compile using all available logical cores
+10. make -j$(sysctl -n hw.ncpu)
 11. make install
 12. "install" SiriKali by just dragging it (in the Finder) from the directory you
     compiled it in to the "Application" directory.


### PR DESCRIPTION
Most often you want to use all your cores when compiling stuff. On linux you can use `nproc` to get the number of logical cores, and on OS X the corresponding command is `sysctl -n hw.ncpu`.

This pull request adds `-j$(sysctl -n hw.ncpu)` to the make command in the OS X installation instructions and the analogous `-j$(nproc)` to the Linux instructions.