### PR TITLE
fixed missing iostream include

### DIFF
--- a/src/siripolkit/zulupolkit.cpp
+++ b/src/siripolkit/zulupolkit.cpp
@@ -26,6 +26,7 @@
 
 #include <termios.h>
 #include <memory>
+#include <iostream>
 
 #include <QProcess>
 #include <QCoreApplication>


### PR DESCRIPTION
There was a include missing in zulupolkit.cpp for std::cout.  