### PR TITLE
Opt out of debug source packages for rpm builds

### DIFF
--- a/rpm/sirikali.spec
+++ b/rpm/sirikali.spec
@@ -43,6 +43,8 @@ BuildRequires: qt5-qtbase-devel
 %description
 SiriKali is a Qt/C++ GUI front end to encfs,cryfs,gocryptfs,ecryptfs and securefs.
 
+%undefine _debugsource_packages
+
 %prep
 %setup -q
 


### PR DESCRIPTION
## Issues

#52 

## Description

Since Fedora 27, the following are enabled by default now:

```
%global _debugsource_packages 1
%global _debuginfo_subpackages 1
```

It looks like the failing builds is due to not building a debug source package, so we should opt out.

## References

- https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/message/6XZAYH5BWT45YF62UVEGE22SO3YYONFJ/


  