### PR TITLE
Refer to the desktop file by a consistent name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -427,7 +427,7 @@ if( NOT APPLE )
 #install( FILES sirikali.png DESTINATION share/icons/hicolor/32x32/apps )
 
 # desktop file section
-file( WRITE ${PROJECT_BINARY_DIR}/sirikali.desktop
+file( WRITE ${PROJECT_BINARY_DIR}/io.github.mhogomchungu.sirikali.desktop
 
 "[Desktop Entry]
 Comment[en_US]=Manage Encrypted Volumes Hosted In Folders
@@ -445,7 +445,7 @@ Type=Application
 MimeType=inode/directory;
 Categories=Security;Utility;Qt;X-MandrivaLinux-System-FileTools;\n")
 
-install( FILES ${PROJECT_BINARY_DIR}/sirikali.desktop
+install( FILES ${PROJECT_BINARY_DIR}/io.github.mhogomchungu.sirikali.desktop
 	DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications
 	PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
 )

--- a/src/sirikali.appdata.xml
+++ b/src/sirikali.appdata.xml
@@ -2,7 +2,7 @@
 <!-- Copyright 2016 David Steele <steele@debian.org> -->
 <component type="desktop">
   <id>io.github.mhogomchungu.SiriKali</id>
-  <launchable type="desktop-id">io.github.mhogomchungu.SiriKali.desktop</launchable>
+  <launchable type="desktop-id">io.github.mhogomchungu.sirikali.desktop</launchable>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0</project_license>
   <name>SiriKali</name>


### PR DESCRIPTION
The name of the desktop file did not match the current name in the appdata xml file. This caused the package to be dropped from the [gnome-software](https://wiki.gnome.org/Apps/Software) database.

Completing 457e492d / #59