### PR TITLE
Fix #102 (2): Set path properly when accessing wallet on volume creation so already existing entries are recognized properly.

### DIFF
--- a/src/keydialog.cpp
+++ b/src/keydialog.cpp
@@ -809,6 +809,11 @@ void keyDialog::pbOpen()
 			m_ui->lineEditMountPoint->setFocus() ;
 
 			return ;
+
+		} else {
+
+			m_path = m_ui->lineEditFolderPath->text();
+
 		}
 	}
 


### PR DESCRIPTION
This did not work before, because `m_path` was never set when creating a new volume despite the user already entered it and the application was always trying to fetch and key for an empty path.