### PR TITLE
Fix #102: Prompt to create a new entry in the wallet on volume creation

### DIFF
--- a/src/walletconfig.cpp
+++ b/src/walletconfig.cpp
@@ -37,10 +37,11 @@
 
 #define COMMENT "-SiriKali_Comment_ID"
 
-walletconfig::walletconfig( QWidget * parent,secrets::wallet&& wallet,std::function< void() > e ) :
+walletconfig::walletconfig( QWidget * parent,secrets::wallet&& wallet,std::function< void() > e,QString folderPath) :
 	QDialog( parent ),
 	m_ui( new Ui::walletconfig ),
 	m_wallet( std::move( wallet ) ),
+	m_volumeID( folderPath ),
 	m_function( std::move( e ) )
 {
 	m_ui->setupUi( this ) ;
@@ -157,7 +158,7 @@ void walletconfig::pbAdd()
 {
 	this->disableAll() ;
 
-	walletconfiginput::instance( m_parentWidget,this,[ this ]( const QString& volumeID,
+	walletconfiginput::instance( m_parentWidget,this,m_volumeID,[ this ]( const QString& volumeID,
 				     const QString& comment,const QString& key ){
 
 		m_comment  = comment ;
@@ -275,6 +276,12 @@ void walletconfig::accessWallet()
 		this->enableAll() ;
 		m_ui->tableWidget->setFocus() ;
 	} ) ;
+
+	/* If m_volumeID is set go straight to pbAdd() */
+	if(!m_volumeID.isEmpty()) {
+		this->pbAdd();
+	}
+
 }
 
 void walletconfig::enableAll()

--- a/src/walletconfig.h
+++ b/src/walletconfig.h
@@ -46,11 +46,11 @@ class walletconfig : public QDialog
 public:
 	static void instance( QWidget * parent,
 			      secrets::wallet&& wallet,
-			      std::function< void() > e = [](){} )
+			      std::function< void() > e = [](){}, QString folderPath = QString() )
 	{
-		new walletconfig( parent,std::move( wallet ),std::move( e ) ) ;
+		new walletconfig( parent,std::move( wallet ),std::move( e ),folderPath ) ;
 	}
-	explicit walletconfig( QWidget * parent,secrets::wallet&&,std::function< void() > ) ;
+	explicit walletconfig( QWidget * parent,secrets::wallet&&,std::function< void() >, QString folderPath ) ;
 	~walletconfig() ;
 	void HideUI( void ) ;
 private slots:

--- a/src/walletconfiginput.cpp
+++ b/src/walletconfiginput.cpp
@@ -29,7 +29,7 @@
 
 #include <QDebug>
 
-walletconfiginput::walletconfiginput( QWidget * parent,QDialog * dialog,
+walletconfiginput::walletconfiginput( QWidget * parent,QDialog * dialog,QString volumeID,
 				      std::function< void( const QString&,const QString&,const QString& ) > p,
 				      std::function< void() > q ) :
 	QDialog( parent ),m_ui( new Ui::walletconfiginput ),m_add( std::move( p ) ),m_cancel( std::move( q ) ),
@@ -47,6 +47,13 @@ walletconfiginput::walletconfiginput( QWidget * parent,QDialog * dialog,
 	m_ui->lineEditVolumeID->setEnabled( true ) ;
 	m_ui->lineEditKey->setEchoMode( QLineEdit::Password ) ;
 	m_ui->lineEditRepeatKey->setEchoMode( QLineEdit::Password ) ;
+
+	/* If volumeID is set, prefill volumeID text field and focus 'Key' field*/
+	if(!volumeID.isEmpty()) {
+		m_ui->lineEditVolumeID->setText(volumeID) ;
+		m_ui->lineEditVolumeID->setDisabled(true);
+		m_ui->lineEditKey->setFocus() ;
+	}
 
 	connect( m_ui->pushButtonAdd,SIGNAL( clicked() ),this,SLOT( pbAdd() ) ) ;
 	connect( m_ui->pushButtonCancel,SIGNAL( clicked() ),this,SLOT( slotCancel() ) ) ;

--- a/src/walletconfiginput.h
+++ b/src/walletconfiginput.h
@@ -38,14 +38,14 @@ class walletconfiginput : public QDialog
 {
 	Q_OBJECT
 public:
-	static walletconfiginput& instance( QWidget * parent,QDialog * dialog,
+	static walletconfiginput& instance( QWidget * parent,QDialog * dialog,QString volumeID,
 					    std::function< void( const QString&,const QString&,const QString& ) > p,
 					    std::function< void() > q )
 	{
-		return *( new walletconfiginput( parent,dialog,std::move( p ),std::move( q ) ) ) ;
+		return *( new walletconfiginput( parent,dialog,volumeID,std::move( p ),std::move( q ) ) ) ;
 	}
 
-	walletconfiginput( QWidget * parent,QDialog *,
+	walletconfiginput( QWidget * parent,QDialog *,QString volumeID,
 			   std::function< void( const QString&,const QString&,const QString& ) >,
 			   std::function< void() > ) ;
 	~walletconfiginput() ;


### PR DESCRIPTION
Solution mentioned in https://github.com/mhogomchungu/sirikali/issues/102#issuecomment-504094875.

It retains all capabilities the user has when creating the entry through the settings: double check password, add comment to entry.

![peek-fix](https://user-images.githubusercontent.com/24757415/59865753-28c0ba80-938a-11e9-85de-d88495dd346b.gif)

Honestly, I prefer this solution over a3af20bd9deca687d8588716c55bb3265dc6ba24, because it doesn't introduce to many changes while retaining all functionality at the cost of 2 more clicks. Maybe we can use the best of both approaches (sorry this sound harsher than I mean to).

**TODO:**
- [ ] disable file chooser in `src/walletconfiginput.cpp` to prevent user from changing volume ID