### PR TITLE
Do not take over dir opening

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -463,7 +463,7 @@ NoDisplay=false
 StartupNotify=true
 Terminal=false
 Type=Application
-MimeType=inode/directory;
+MimeType=inode/directory:1;
 Categories=Security;Utility;Qt;X-MandrivaLinux-System-FileTools;\n")
 
 install( FILES ${PROJECT_BINARY_DIR}/io.github.mhogomchungu.sirikali.desktop


### PR DESCRIPTION
Hi!
Without this, I always end up in Sirikali when doing any "Open folder" activity, being in Firefox, Android Studio, etc. I expect to see a file manager and files, when opening a directory