### PR TITLE
Set QApplication::desktopFileName

### DIFF
--- a/src/sirikali.cpp
+++ b/src/sirikali.cpp
@@ -213,6 +213,7 @@ int sirikali::run( const QStringList& args,int argc,char * argv[] )
 		QApplication srk( argc,argv ) ;
 
 		srk.setApplicationName( "SiriKali" ) ;
+		srk.setDesktopFileName( "io.github.mhogomchungu.sirikali" ) ;
 
 		return starter( args,srk ).exec() ;
 	}


### PR DESCRIPTION
This ensures that the proper desktop file name is communicated to the window system, which is important for proper window/taskbar icons and startup feedback