### PR TITLE
Fix sirikali unable to find gocryptfs binary on M series Macs

### DIFF
--- a/src/engines.cpp
+++ b/src/engines.cpp
@@ -72,7 +72,8 @@ static QStringList _system_search_paths()
 		 "/opt/local/bin/",
 		 "/opt/local/sbin/",
 		 "/opt/bin/",
-		 "/opt/sbin/" } ;
+		 "/opt/sbin/",
+		 "/opt/homebrew/bin/" } ;
 }
 
 static QStringList _search_path_0( const QString& e )


### PR DESCRIPTION
Now everything works as expected