### PR TITLE
fix: The KeyType control can not use.

### DIFF
--- a/src/keydialog.cpp
+++ b/src/keydialog.cpp
@@ -1484,6 +1484,7 @@ void keyDialog::pbSetKeyCancel()
 	this->setUIVisible( true ) ;
 	this->enableAll() ;
 	m_keyType.setAsKey() ;
+    m_keyType.setEnabled(true) ;
 }
 
 void keyDialog::setKeyEnabled( bool e )


### PR DESCRIPTION
When set the "Key+KeyFile" type, then clicked "cancel" button, The KeyType control can not use.

Log: fix issue
Issue: https://github.com/mhogomchungu/sirikali/issues/251