### PR TITLE
Fix AppStream metainfo summary/description

### DIFF
--- a/src/flatpak/io.github.mhogomchungu.sirikali.metainfo.xml
+++ b/src/flatpak/io.github.mhogomchungu.sirikali.metainfo.xml
@@ -5,7 +5,7 @@
 
 	<name>SiriKali</name>
 
-	<summary>A GUI to gocryptfs, securefs, cryfs.</summary>
+	<summary>A GUI to gocryptfs, securefs, cryfs</summary>
 
 	<metadata_license>FSFAP</metadata_license>
 
@@ -20,7 +20,7 @@
 		  <name>Francis Banyikwa</name>
 	</developer>
 
-	<description><p>This application makes it easy to store your documents in a secured folder. Securefs is bundled with the application and users who prefer to use gocryptfs or Cryfs should add them to "/home/ink/.var/app/io.github.mhogomchungu.sirikali/data/SiriKali/bin" folder</p></description>
+	<description><p>This application makes it easy to store your documents in a secured folder. Securefs is bundled with the application and users who prefer to use gocryptfs or Cryfs should add them to "/home/ink/.var/app/io.github.mhogomchungu.sirikali/data/SiriKali/bin" folder.</p></description>
 
 	<launchable type="desktop-id">io.github.mhogomchungu.sirikali.desktop</launchable>
 


### PR DESCRIPTION
Summary should not end with a dot, description should.